### PR TITLE
Check callback is a functionbefore calling

### DIFF
--- a/logger.js
+++ b/logger.js
@@ -108,7 +108,7 @@ function logMethod(logger, levelName, level) {
                 return;
             }
 
-            if (callback) {
+            if (callback && typeof callback === 'function') {
                 return callback(err);
             }
 


### PR DESCRIPTION
If someone calls `logger.info('message', foo, bar, baz);` or whatever that doesn't match `log('string', obj, cb)` it tries to call cb against the 3rd parameter regardless of if it's a function.

We could consider doing stronger validation on the call site. I'd like to find some way to avoid cascading logging errors.
