### PR TITLE
turn trace off by default

### DIFF
--- a/default-levels.js
+++ b/default-levels.js
@@ -11,7 +11,7 @@ var defaultBackends = ['disk', 'kafka', 'console'];
 
 var defaultLevels = {
     trace: {
-        backends: ['console'],
+        backends: [],
         level: TRACE
     },
     debug: {


### PR DESCRIPTION
The trace level is starting to get used by
libraries. This should not be on by default as it will
be very noisy.

Having it on by default will create a bad user experience
for application developers running their tests or running
their servers locally.

reviewers: @jwolski @kriskowal @robskillington

cc: @sh1mmer