### PR TITLE
Use log Entry objects

### DIFF
--- a/backends/logger-stream.js
+++ b/backends/logger-stream.js
@@ -17,12 +17,11 @@ function LoggerStream(logger, opts, destroyCb) {
 
 inherits(LoggerStream, Writable);
 
-LoggerStream.prototype._write = function write(triplet, enc, cb) {
-    var levelName = triplet[0];
-    var message = triplet[1];
-    var chunk = triplet[2];
-
-    this.logger.log(levelName, message, chunk, cb);
+LoggerStream.prototype._write = function write(entry, enc, cb) {
+    var level = entry.level;
+    var message = entry.message;
+    var meta = entry.meta;
+    this.logger.log(level, message, meta, cb);
 };
 
 LoggerStream.prototype.destroy = function destroy() {

--- a/entry.js
+++ b/entry.js
@@ -1,0 +1,10 @@
+'use strict';
+
+module.exports = Entry;
+function Entry(level, message, meta, path) {
+    this.level = level;
+    this.message = message;
+    this.meta = meta;
+    this.path = path;
+}
+

--- a/transforms/pid-and-host.js
+++ b/transforms/pid-and-host.js
@@ -1,19 +1,23 @@
+'use strict';
+
+var Entry = require('../entry.js');
+
 module.exports = AddPidAndHost;
 
-function AddPidAndHost(meta) {
+function AddPidAndHost(baseMeta) {
     return addPidAndHost;
 
-    function addPidAndHost(triplet) {
-        var opts = triplet[2] || {};
+    function addPidAndHost(entry) {
+        var meta = entry.meta || {};
 
-        if (!opts._hostname && meta.hostname) {
-            opts._hostname = meta.hostname;
+        if (!meta._hostname && baseMeta.hostname) {
+            meta._hostname = baseMeta.hostname;
         }
 
-        if (!opts._pid && meta.pid) {
-            opts._pid = meta.pid;
+        if (!meta._pid && baseMeta.pid) {
+            meta._pid = baseMeta.pid;
         }
 
-        return [triplet[0], triplet[1], opts];
+        return new Entry(entry.level, entry.message, entry.meta, entry.path);
     }
 }

--- a/transforms/serialize-error.js
+++ b/transforms/serialize-error.js
@@ -1,20 +1,21 @@
 var isError = require('core-util-is').isError;
+var Entry = require('../entry.js');
 
 module.exports = serializableError;
 
-function serializableError(triplet) {
-    var opts = triplet[2];
-    if (isError(opts)) {
-        makeSerializable(opts);
-    } else if (typeof opts === 'object' && opts !== null) {
-        Object.keys(opts).forEach(function (k) {
-            if (isError(opts[k])) {
-                makeSerializable(opts[k]);
+function serializableError(entry) {
+    var meta = entry.meta;
+    if (isError(meta)) {
+        makeSerializable(meta);
+    } else if (typeof meta === 'object' && meta !== null) {
+        Object.keys(meta).forEach(function (k) {
+            if (isError(meta[k])) {
+                makeSerializable(meta[k]);
             }
         });
     }
 
-    return [triplet[0], triplet[1], opts];
+    return new Entry(entry.level, entry.message, entry.meta, entry.path);
 }
 
 function makeSerializable(error) {

--- a/transforms/xtend.js
+++ b/transforms/xtend.js
@@ -1,15 +1,14 @@
 var extend = require('xtend');
+var Entry = require('../entry.js');
 
 module.exports = XtendTransform;
 
-function XtendTransform(meta) {
+function XtendTransform(baseMeta) {
     return xtendTransform;
 
-    function xtendTransform(triplet) {
-        var opts = triplet[2] || {};
-
-        opts = extend(meta, opts);
-
-        return [triplet[0], triplet[1], opts];
+    function xtendTransform(entry) {
+        var meta = entry.meta || {};
+        meta = extend(baseMeta, meta);
+        return new Entry(entry.level, entry.message, meta, entry.path);
     }
 }


### PR DESCRIPTION
Instead of triples, which would now be quadruples, since entries also
carry a log path in anticipation of a log tree.