### PR TITLE
Fixes problem with shared mutable defaults

### DIFF
--- a/logger.js
+++ b/logger.js
@@ -58,8 +58,8 @@ function Logger(opts) {
             }
 
             var level = levels[levelName];
-            level.transforms = (level.transforms || [])
-                .concat(transforms);
+            level = extend({transforms: []}, level);
+            level.transforms = level.transforms.concat(transforms);
 
             this[levelName] = logMethod(this, levelName, level);
         }, this);

--- a/test/default-backends.js
+++ b/test/default-backends.js
@@ -12,6 +12,7 @@ var SentryServer = require(
 var KafkaServer = require(
     'kafka-logger/test/lib/kafka-server.js');
 
+var defaultLevels = require('../default-levels.js');
 var captureStdio = require('./lib/capture-stdio.js');
 var Logger = require('../index.js');
 
@@ -263,4 +264,9 @@ test('kafka logging', function t(assert) {
         server.close();
         assert.end();
     }
+});
+
+test('default levels have not been altered', function t(assert) {
+    assert.ok(!('transforms' in defaultLevels.trace));
+    assert.end();
 });


### PR DESCRIPTION
Previously, each default log level object was shared by every logger
instance that used that default log level.
The default log level would have transforms added to it, and each
instance would append the same two transforms to the end, accumulating
with each logger instance.
This should not occur in production since there is only one logger
instance per application, but does occur during testing.

review @Raynos 