### PR TITLE
JSON mode + buffer support.

### DIFF
--- a/backends/console.js
+++ b/backends/console.js
@@ -4,10 +4,12 @@ var EventEmitter = require('events').EventEmitter;
 var ConsoleLogger = require('../lib/async-console-transport.js');
 var LoggerStream = require('./logger-stream.js');
 
-function ConsoleBackend() {
+function ConsoleBackend(opts) {
     if (!(this instanceof ConsoleBackend)) {
-        return new ConsoleBackend();
+        return new ConsoleBackend(opts);
     }
+
+    this.raw = opts ? opts.raw : false;
 
     EventEmitter.call(this);
 }
@@ -17,7 +19,8 @@ inherits(ConsoleBackend, EventEmitter);
 ConsoleBackend.prototype.createStream =
     function createStream(meta, opts) {
         var logger = new ConsoleLogger({
-            timestamp: true
+            timestamp: true,
+            raw: this.raw
         });
 
         return LoggerStream(logger, {

--- a/backends/disk.js
+++ b/backends/disk.js
@@ -17,6 +17,7 @@ function DiskBackend(opts) {
     EventEmitter.call(this);
 
     this.folder = opts.folder;
+    this.json = opts.json || false;
 }
 
 inherits(DiskBackend, EventEmitter);
@@ -27,7 +28,7 @@ DiskBackend.prototype.createStream =
         var logger = new DailyRotateFile({
             filename: path.join(this.folder, fileName),
             datePattern: '-yyyyMMdd',
-            json: false
+            json: this.json
         });
 
         return LoggerStream(logger, {

--- a/index.js
+++ b/index.js
@@ -51,7 +51,8 @@ function defaultBackends(config, clients) {
     return {
         _isDefaultBackends: true,
         disk: config.logFolder ? Disk({
-            folder: config.logFolder
+            folder: config.logFolder,
+            json: config.json || false
         }) : null,
         kafka: config.kafka ? Kafka({
             leafHost: config.kafka.leafHost,
@@ -60,7 +61,9 @@ function defaultBackends(config, clients) {
             statsd: clients.statsd,
             kafkaClient: clients.kafkaClient
         }) : null,
-        console: config.console ? Console() : null,
+        console: config.console ? Console({
+            raw: config.raw || false
+        }) : null,
         sentry: config.sentry ? Sentry({
             dsn: config.sentry.id,
             statsd: clients.statsd

--- a/lib/async-console-transport.js
+++ b/lib/async-console-transport.js
@@ -7,8 +7,8 @@
  */
 
 var util = require('util');
-var common = require('winston/lib/winston/common.js');
-var Transport = require('winston').Transport;
+var common = require('winston-uber/lib/winston/common.js');
+var Transport = require('winston-uber').Transport;
 
 //
 // ### function AsyncConsole (options)

--- a/lib/mkdir-daily-rotate-file.js
+++ b/lib/mkdir-daily-rotate-file.js
@@ -1,4 +1,4 @@
-var DailyRotateFile = require('winston').transports.DailyRotateFile;
+var DailyRotateFile = require('winston-uber').transports.DailyRotateFile;
 var fs = require('fs');
 var mkdirp = require('mkdirp');
 var util = require('util');

--- a/package.json
+++ b/package.json
@@ -16,15 +16,15 @@
     "core-util-is": "^1.0.1",
     "error": "^4.0.0",
     "inherits": "^2.0.1",
-    "kafka-logger": "4.2.0",
+    "kafka-logger": "^5.0.0",
     "lodash.isfinite": "~2.4.1",
     "mkdirp": "~0.3.5",
     "nodemailer": "~0.5.14",
     "readable-stream": "^1.0.27-1",
     "run-parallel": "^1.0.0",
-    "sentry-logger": "^2.1.0",
+    "sentry-logger": "^3.0.0",
     "uber-raven": "^0.6.3-project-name",
-    "winston": "~0.7.2",
+    "winston-uber": "^1.0.0",
     "xtend": "^3.0.0"
   },
   "devDependencies": {

--- a/test/buffer-objects.js
+++ b/test/buffer-objects.js
@@ -1,0 +1,104 @@
+'use strict';
+
+var Buffer = require('buffer').Buffer;
+var test = require('tape');
+
+var captureStdio = require('./lib/capture-stdio.js');
+var ConsoleLogger = require('./lib/console-logger.js');
+var FileLogger = require('./lib/file-logger.js');
+var SentryLogger = require('./lib/sentry-logger.js');
+var KafkaLogger = require('./lib/kafka-logger.js');
+
+test('writing a buffer object (console)', function t(assert) {
+    var logger = ConsoleLogger();
+
+    var meta = allocBufferMeta();
+
+    assert.ok(captureStdio('info: cool story buf=b2ggaGk', function log() {
+        logger.info('cool story', meta, function cb(err) {
+            assert.ifError(err);
+
+            logger.destroy();
+            assert.end();
+        });
+    }));
+});
+
+test('writing a buffer object (disk)', function t(assert) {
+    var logger = FileLogger();
+
+    var meta = allocBufferMeta();
+
+    logger.info('cool story', meta, function log(err) {
+        assert.ifError(err);
+
+        logger.readFile(function onFile(err, buf) {
+            assert.ifError(err);
+
+            assert.ok(buf.indexOf('info: cool story buf=b2ggaGk') !== -1);
+
+            logger.destroy();
+            assert.end();
+        });
+    });
+});
+
+test('writing a buffer object (sentry)', function t(assert) {
+    var messages = [];
+    var logger = SentryLogger(function listener(msg) {
+        messages.push(msg);
+
+        if (messages.length === 1) {
+            onLogged();
+        }
+    });
+
+    var meta = allocBufferMeta();
+
+    logger.error('cool story', meta);
+
+    function onLogged() {
+        var msg = messages[0];
+
+        assert.ok(msg.message.indexOf('cool story') !== -1);
+
+        logger.destroy();
+        assert.end();
+    }
+});
+
+test('writing a buffer object (kafka)', function t(assert) {
+    var messages = [];
+    var logger = KafkaLogger(function listener(msg) {
+        messages.push(msg);
+
+        if (messages.length === 1) {
+            onLogged();
+        }
+    });
+
+    var meta = allocBufferMeta();
+
+    logger.info('cool story', meta);
+
+    function onLogged() {
+        var msg = messages[0];
+
+        var payload = msg.messages[0].payload;
+
+        assert.ok(payload.msg.indexOf('cool story') !== -1);
+
+        logger.destroy();
+        assert.end();
+    }
+});
+
+function allocBufferMeta() {
+    var meta = {};
+    meta.buf = new Buffer('oh hi');
+    meta.ohWhat = {
+        someBuf: new Buffer('oh wat')
+    };
+
+    return meta;
+}

--- a/test/index.js
+++ b/test/index.js
@@ -25,6 +25,7 @@ require('./access.js');
 require('./leaky-backend-master.js');
 require('./kafka-is-disabled.js');
 require('./child-logger.js');
+require('./buffer-objects.js');
 
 test('removing levels', function t(assert) {
     var logger = Logger({

--- a/test/index.js
+++ b/test/index.js
@@ -26,6 +26,7 @@ require('./leaky-backend-master.js');
 require('./kafka-is-disabled.js');
 require('./child-logger.js');
 require('./buffer-objects.js');
+require('./raw-logger.js');
 
 test('removing levels', function t(assert) {
     var logger = Logger({

--- a/test/lib/console-logger.js
+++ b/test/lib/console-logger.js
@@ -1,13 +1,17 @@
+'use strict';
+
 var Logger = require('../../logger.js');
 var ConsoleBackend = require('../../backends/console.js');
 
 module.exports = createLogger;
 
-function createLogger() {
+function createLogger(opts) {
     return Logger({
         meta: {},
         backends: {
-            console: ConsoleBackend()
+            console: ConsoleBackend({
+                raw: opts ? opts.raw : false
+            })
         }
     });
 }

--- a/test/raw-logger.js
+++ b/test/raw-logger.js
@@ -1,0 +1,64 @@
+'use strict';
+
+var test = require('tape');
+
+var captureStdio = require('./lib/capture-stdio.js');
+var ConsoleLogger = require('./lib/console-logger.js');
+var FileLogger = require('./lib/file-logger.js');
+
+test('writing a buffer object (console)', function t(assert) {
+    var logger = ConsoleLogger({
+        raw: true
+    });
+
+    var meta = allocMeta();
+
+    assert.ok(captureStdio(
+        '{"someKey":"hi","some":{"nestedKey":"oh hi"},' +
+            '"level":"info","message":"cool story"}',
+        function log() {
+            logger.info('cool story', meta, function cb(err) {
+                assert.ifError(err);
+
+                logger.destroy();
+                assert.end();
+            });
+        }));
+});
+
+test('writing a buffer object (disk)', function t(assert) {
+    var logger = FileLogger({
+        json: true
+    });
+
+    var meta = allocMeta();
+
+    logger.info('cool story', meta, function log(err) {
+        assert.ifError(err);
+
+        logger.readFile(function onFile(err2, buf) {
+            assert.ifError(err2);
+
+            assert.notEqual(
+                buf.indexOf(
+                    '{"someKey":"hi","some":{"nestedKey":"oh hi"},' +
+                    '"level":"info","message":"cool story"'
+                ),
+                -1
+            );
+
+            logger.destroy();
+            assert.end();
+        });
+    });
+});
+
+function allocMeta() {
+    var meta = {};
+    meta.someKey = 'hi';
+    meta.some = {
+        nestedKey: 'oh hi'
+    };
+
+    return meta;
+}


### PR DESCRIPTION
Logtron currently serializes buffers in a terrible way by printing
1 million numbers.

The upgrade to `winston-uber` fixes this.

Logtron currently has some weird serialization format that is
not JSON for console & disk.

I've exposed the `raw` and `json` options to allow users to
turn those features on.

reviewers: @rf @kriskowal