### PR TITLE
Fix sentry by deep copying entry objects

### DIFF
--- a/lib/parallel-write.js
+++ b/lib/parallel-write.js
@@ -1,8 +1,10 @@
+var isError = require('core-util-is').isError;
+var deepExtend = require('deep-extend');
 var ValidationError = require('error/validation');
 
 module.exports = parallelWrite;
 
-function parallelWrite(logStreams, chunk, callback) {
+function parallelWrite(logStreams, entry, callback) {
     var errors = [];
     var pending = logStreams.length;
 
@@ -15,7 +17,15 @@ function parallelWrite(logStreams, chunk, callback) {
                 return next();
             }
 
-            stream.write(chunk, next);
+            var copy;
+            if (logStreams[i].name === 'sentry') {
+                copy = magicCopy(entry);
+                // copy = entry;
+            } else {
+                copy = entry;
+            }
+
+            stream.write(copy, next);
         }
     } else {
         callback(null);
@@ -41,4 +51,66 @@ function writableIsFull(s) {
     var state = s._writableState;
 
     return state.length >= state.highWaterMark;
+}
+
+/** sentry is a magical special best.
+
+We must deep copy the log entry because sentry mutates it.
+This means if we write to sentry first we will write malformed
+data to kafka or disk.
+
+This is a magical deep copy because it can deep copy error objects
+
+*/
+function magicCopy(entry) {
+    if (isError(entry)) {
+        return magicCopyError(entry);
+    }
+
+    var copy = deepExtend({}, entry);
+
+    if (typeof entry === 'object' && entry !== null) {
+        Object.keys(entry).forEach(function copyProp(k) {
+            var value = entry[k];
+            if (isError(value)) {
+                copy[k] = magicCopyError(value);
+            } else if (typeof value === 'object' && value !== null) {
+                copy[k] = magicCopy(entry[k]);
+            }
+        });
+    }
+
+    return copy;
+}
+
+function magicCopyError(origError) {
+    // TODO sub classing error... ...
+    var freshError = new Error(origError.message);
+    // Copying the stack is valid...
+    freshError.stack = origError.stack;
+
+    // copy keys before making message & stack enumerable
+    Object.keys(origError).forEach(function copyProp(k) {
+        var value = origError[k];
+
+        if (typeof value === 'object' && value !== null) {
+            freshError[k] = magicCopy(value);
+        } else {
+            freshError[k] = value;
+        }
+    });
+
+    Object.defineProperty(freshError, 'message', {
+        value: freshError.message,
+        enumerable: true,
+        configurable: true
+    });
+
+    Object.defineProperty(freshError, 'stack', {
+        value: freshError.stack,
+        enumerable: true,
+        configurable: true
+    });
+
+    return freshError;
 }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "airlock": "^2.1.1",
     "core-util-is": "^1.0.1",
+    "deep-extend": "0.4.0",
     "error": "^4.0.0",
     "inherits": "^2.0.1",
     "kafka-logger": "^5.0.0",

--- a/test/errors-with-all-backends.js
+++ b/test/errors-with-all-backends.js
@@ -1,0 +1,98 @@
+var test = require('tape');
+
+var captureStdio = require('./lib/capture-stdio.js');
+var FatLogger = require('./lib/fat-logger.js');
+
+test('can error(message, { err: err })', function t(assert) {
+    var kafkaMessages = [];
+    var sentryMessages = [];
+    var logger = FatLogger({
+        raw: true,
+        json: true,
+        kafkaListener: kafkaListener,
+        sentryListener: sentryListener
+    });
+
+    var streams = logger._streamsByLevel.error;
+    assert.ok(streams[3].name === 'sentry');
+    // insert sentry as the first stream
+    streams.unshift(streams.pop());
+    assert.ok(streams[0].name === 'sentry');
+
+    var consoleBuf = captureStdio(null, function logError() {
+        logger.error('some message', {
+            err: new Error('hello'),
+            other: 'key'
+        }, function delay() {
+            // delay by 100ms for sentry
+            setTimeout(onLogged, 100);
+        });
+    }, {
+        raw: true
+    });
+
+    function onLogged() {
+        assert.equal(consoleBuf.length, 1);
+        var consoleObj = JSON.parse(consoleBuf[0]);
+
+        // console.log('consoleObj', consoleObj);
+
+        assert.ok(consoleObj.err);
+        assert.ok(consoleObj.err.stack);
+        assert.equal(consoleObj.err.message, 'hello');
+        assert.equal(consoleObj.other, 'key');
+        assert.equal(consoleObj.message, 'some message');
+
+        assert.equal(kafkaMessages.length, 1);
+        var payload = kafkaMessages[0].messages[0].payload;
+
+        // console.log('p', payload);
+
+        assert.ok(payload.fields.err);
+        assert.ok(payload.fields.err.stack);
+        assert.equal(payload.fields.err.message, 'hello');
+        assert.equal(payload.fields.other, 'key');
+        assert.equal(payload.msg, 'some message');
+
+        assert.equal(sentryMessages.length, 1);
+        var sentryMsg = sentryMessages[0];
+
+        // console.log('what.', sentryMsg);
+        
+        assert.equal(sentryMsg.extra.other, 'key');
+        assert.equal(sentryMsg.extra.originalMessage,
+            'some message');
+        assert.equal(sentryMsg.message,
+            'Error: errors-with-all-backends.js: hello');
+        var stackTrace = sentryMsg['sentry.interfaces.Stacktrace'];
+        assert.ok(stackTrace.frames.length);
+
+        logger.readFile(function onFile(err, file) {
+            assert.ifError(err);
+
+            var lines = file.split('\n')
+                .filter(Boolean)
+                .map(JSON.parse);
+
+            assert.equal(lines.length, 1);
+            var diskObj = lines[0];
+
+            assert.ok(diskObj.err);
+            assert.ok(diskObj.err.stack);
+            assert.equal(diskObj.err.message, 'hello');
+            assert.equal(diskObj.other, 'key');
+            assert.equal(diskObj.message, 'some message');
+
+            logger.destroy();
+            assert.end();
+        });
+    }
+
+    function kafkaListener(msg) {
+        kafkaMessages.push(msg);
+    }
+
+    function sentryListener(msg) {
+        sentryMessages.push(msg);
+    }
+});

--- a/test/lib/capture-stdio.js
+++ b/test/lib/capture-stdio.js
@@ -15,6 +15,10 @@ function captureStdio(expected, fn, opts) {
     process.stdout.write = _outwrite;
     process.stderr.write = _errwrite;
 
+    if (opts && opts.raw) {
+        return buf;
+    }
+
     return buf.some(function (line) {
         return line.indexOf(expected) !== -1;
     });

--- a/test/lib/fat-logger.js
+++ b/test/lib/fat-logger.js
@@ -1,0 +1,139 @@
+'use strict';
+
+var path = require('path');
+var os = require('os');
+var uuid = require('uuid');
+var rimraf = require('rimraf');
+var fs = require('fs');
+var dateFormat = require('date-format');
+var assert = require('assert');
+var inherits = require('util').inherits;
+
+var KafkaServer = require(
+    'kafka-logger/test/lib/kafka-server.js');
+var SentryServer = require(
+    'sentry-logger/test/lib/sentry-server.js');
+var Logger = require('../../logger.js');
+var ConsoleBackend = require('../../backends/console.js');
+var DiskBackend = require('../../backends/disk.js');
+var KafkaBackend = require('../../backends/kafka.js');
+var SentryBackend = require('../../backends/sentry.js');
+
+var Levels = {
+    TRACE: 10,
+    DEBUG: 20,
+    INFO: 30,
+    ACCESS: 35,
+    WARN: 40,
+    ERROR: 50,
+    FATAL: 60
+};
+
+module.exports = FatLogger;
+
+function FatLogger(opts) {
+    if (!(this instanceof FatLogger)) {
+        return new FatLogger(opts);
+    }
+
+    var self = this;
+
+    opts = opts || {};
+    self.opts = opts;
+    self.doCleanup = !opts.folder;
+
+    assert(self.opts.sentryListener, 'need sentryListener');
+    assert(self.opts.kafkaListener, 'need kafkaListener');
+
+    if (!self.opts.folder) {
+        self.opts.folder = path.join(os.tmpDir(), uuid());
+    }
+    if (!self.opts.dsn) {
+        self.sentryServer = SentryServer(self.opts.sentryListener);
+        self.opts.dsn = self.sentryServer.dsn;
+    }
+
+    self.kafkaServer = KafkaServer(self.opts.kafkaListener);
+
+    Logger.call(self, {
+        meta: {
+            team: 'rt',
+            project: 'foobar'
+        },
+        backends: {
+            console: ConsoleBackend({
+                raw: opts ? opts.raw : false
+            }),
+            disk: DiskBackend(opts),
+            kafka: KafkaBackend({
+                leafHost: 'localhost',
+                leafPort: self.kafkaServer.port,
+                isDisabled: false,
+                statsd: null,
+                kafkaClient: null
+            }),
+            sentry: SentryBackend(opts)
+        },
+        levels: {
+            trace: {
+                backends: [],
+                level: Levels.TRACE
+            },
+            debug: {
+                backends: ['disk', 'console'],
+                level: Levels.DEBUG
+            },
+            info: {
+                backends: ['disk', 'kafka', 'console'],
+                level: Levels.INFO
+            },
+            access: {
+                backends: ['access'],
+                level: Levels.ACCESS
+            },
+            warn: {
+                backends: ['disk', 'kafka', 'console'],
+                level: Levels.WARN
+            },
+            error: {
+                backends: ['disk', 'kafka', 'console', 'sentry'],
+                level: Levels.ERROR
+            },
+            fatal: {
+                backends: ['disk', 'kafka', 'console', 'sentry'],
+                level: Levels.FATAL
+            }
+        }
+    });
+}
+inherits(FatLogger, Logger);
+
+FatLogger.prototype.destroy = function destroy() {
+    var self = this;
+
+    if (self.doCleanup) {
+        rimraf.sync(self.opts.folder);
+    }
+    if (self.kafkaServer) {
+        self.kafkaServer.close();
+    }
+    if (self.sentryServer) {
+        self.sentryServer.close();
+    }
+
+    Logger.prototype.destroy.apply(this, arguments);
+};
+
+FatLogger.prototype.readFile = function readFile(callback) {
+    var self = this;
+
+    var fileUri = 'rt-foobar.log-' + dateFormat('yyyyMMdd');
+    var uri = path.join(self.opts.folder, fileUri);
+    fs.readFile(uri, function onFile(err, buf) {
+        if (err) {
+            return callback(err);
+        }
+
+        callback(null, String(buf));
+    });
+};


### PR DESCRIPTION
Sentry backend is weird and mutates the error
object which breaks the other backends.

I've added a magic deep copy that works around this

r: @jcorbin @kriskowal