### PR TITLE
cast non-object meta to object

### DIFF
--- a/log-method.js
+++ b/log-method.js
@@ -9,7 +9,15 @@ function makeLogMethod(levelName) {
 
     function log(message, meta, callback) {
         /*jshint validthis:true*/
+
+        if (typeof meta !== 'object' || meta === null) {
+            meta = {
+                nonObjectMeta: meta
+            };
+        }
+
         var entry = new Entry(levelName, message, meta, this.path);
+
         this.writeEntry(entry, callback);
     }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -27,6 +27,7 @@ require('./kafka-is-disabled.js');
 require('./child-logger.js');
 require('./buffer-objects.js');
 require('./raw-logger.js');
+require('./writing-weird-meta-objects.js');
 
 test('removing levels', function t(assert) {
     var logger = Logger({

--- a/test/writing-weird-meta-objects.js
+++ b/test/writing-weird-meta-objects.js
@@ -1,0 +1,27 @@
+'use strict';
+
+var test = require('tape');
+
+var FileLogger = require('./lib/file-logger.js');
+
+test('writing a circular object (disk)', function t(assert) {
+    var logger = FileLogger({
+        json: true
+    });
+
+    logger.info('cool story', 'some str', function log(err) {
+        assert.ifError(err);
+
+        logger.readFile(function (err, buf) {
+            assert.ifError(err);
+
+            var value = JSON.parse(String(buf));
+            assert.equal(value.nonObjectMeta, 'some str');
+            assert.equal(value.message, 'cool story');
+            assert.equal(value.level, 'info');
+
+            logger.destroy();
+            assert.end();
+        });
+    });
+});


### PR DESCRIPTION
Sometimes we might log a non-object and it can confuse
the backends.

For example if you log a string to Sentry it gets
confused.

To work around this we just wrap it in an object

cc @jwyuan @kriskowal