### PR TITLE
Support Logging Dynamic Fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,7 +369,20 @@ Opts specificies options for the child logger. The available
   replace any missing parent methods with a no-op function.
   If you wish to add meta data to each log entry the child
   set the `extendMeta` key to `true` and the `meta` to an
-  object with your meta data.
+  object with your meta data. The `filterMeta` key takes an 
+  array of objects which will create filters that are run 
+  at log time. This allows you to automatically add the 
+  current value of an object property to the log meta without 
+  having to manual add the values at each log site. The format
+  of a filter object is:
+```js
+{'oject': targetObj, 'mappings': {'src': 'dst', 'src2': 'dst2'}}
+```
+  Each filter has an object key which is the target the data
+  will be taken from. The mappings object contains keys which
+  are the src of the data on the target object as a dot path 
+  and the destination it will be placed in on the meta object.
+  A log site can still override this destination though.
 
 ```js
 logger.createChild("supervisor", {

--- a/README.md
+++ b/README.md
@@ -360,7 +360,7 @@ Child loggers implement log level methods for every key in
   there isn't an object laying around with the keys you
   need.
 
-Opts specificies options for the child logger. The available
+Opts specifies options for the child logger. The available
   options are to enable strict mode, and to add metadata to
   each entry. To enable strict mode pass the `strict` key in
   the options with a true value. In strict mode the child

--- a/README.md
+++ b/README.md
@@ -374,10 +374,7 @@ Opts specificies options for the child logger. The available
   at log time. This allows you to automatically add the 
   current value of an object property to the log meta without 
   having to manual add the values at each log site. The format
-  of a filter object is:
-```js
-{'oject': targetObj, 'mappings': {'src': 'dst', 'src2': 'dst2'}}
-```
+  of a filter object is: `{'oject': targetObj, 'mappings': {'src': 'dst', 'src2': 'dst2'}}`
   Each filter has an object key which is the target the data
   will be taken from. The mappings object contains keys which
   are the src of the data on the target object as a dot path 
@@ -385,7 +382,8 @@ Opts specificies options for the child logger. The available
   A log site can still override this destination though.
 
 ```js
-logger.createChild("supervisor", {
+
+logger.createChild("requestHandler", {
     info: true,
     warn: true,
     log: true,
@@ -393,8 +391,13 @@ logger.createChild("supervisor", {
 }, {
     extendMeta: true,
     meta: {
-        myBaseMetaKey: 'myBaseMetaVal'
-    }
+        sessionKey: 'abc123'
+    },
+    metaFilter: [
+        {object: res, mappings: {
+            'headersSent' : 'headersSent'
+        }
+    ]
 })
 ```
 

--- a/README.md
+++ b/README.md
@@ -374,7 +374,7 @@ Opts specificies options for the child logger. The available
   at log time. This allows you to automatically add the 
   current value of an object property to the log meta without 
   having to manual add the values at each log site. The format
-  of a filter object is: `{'oject': targetObj, 'mappings': {'src': 'dst', 'src2': 'dst2'}}`
+  of a filter object is: `{'oject': targetObj, 'mappings': {'src': 'dst', 'src2': 'dst2'}}`.
   Each filter has an object key which is the target the data
   will be taken from. The mappings object contains keys which
   are the src of the data on the target object as a dot path 
@@ -390,9 +390,13 @@ logger.createChild("requestHandler", {
     trace: true
 }, {
     extendMeta: true,
+    // Each time we log this will include the session key
     meta: {
         sessionKey: 'abc123'
     },
+    // Each time we log this will include if the headers
+    // have been written to the client yet based on the
+    // current value of res.headersSent
     metaFilter: [
         {object: res, mappings: {
             'headersSent' : 'headersSent'

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ type Logger := {
     error: (message: String, meta: Object, cb? Callback) => void,
     fatal: (message: String, meta: Object, cb? Callback) => void,
     writeEntry: (Entry, cb?: Callback) => void,
-    createChild: (path: String, Object<levelName: String>) => Logger
+    createChild: (path: String, Object<levelName: String>, Object<opts: String>) => Logger
 }
 
 type LogtronLogger := EventEmitter & Logger & {
@@ -344,7 +344,7 @@ It's expected that shutdown the process once you have verified
   that the `fatal()` error message has been logged. You can
   do either a hard or soft shutdown.
 
-#### `logger.createChild({path: String, levels?})`
+#### `logger.createChild({path: String, levels?, opts?})`
 
 The `createChild` method returns a Logger that will create entries at a
   nested path.
@@ -360,12 +360,28 @@ Child loggers implement log level methods for every key in
   there isn't an object laying around with the keys you
   need.
 
+Opts specificies options for the child logger. The available
+  options are to enable strict mode, and to add metadata to
+  each entry. To enable strict mode pass the `strict` key in
+  the options with a true value. In strict mode the child
+  logger will ensure that each log level has a corrisponding
+  backend in the parent logger. Otherwise the logger will
+  replace any missing parent methods with a no-op function.
+  If you wish to add meta data to each log entry the child
+  set the `extendMeta` key to `true` and the `meta` to an
+  object with your meta data.
+
 ```js
 logger.createChild("supervisor", {
     info: true,
     warn: true,
     log: true,
     trace: true
+}, {
+    extendMeta: true,
+    meta: {
+        myBaseMetaKey: 'myBaseMetaVal'
+    }
 })
 ```
 

--- a/child-logger.js
+++ b/child-logger.js
@@ -16,13 +16,21 @@ function ChildLogger(config) {
     }
     this.extendMeta = config.extendMeta;
     this.meta = config.meta;
+    this.strict = config.strict;
 
     var levels = config.levels || defaultLevels;
     Object.keys(levels).forEach(function (levelName) {
         if (!this.mainLogger.levels.hasOwnProperty(levelName)) {
-            throw errors.LevelRequired({level: levelName});
+            if (this.strict) {
+                throw errors.LevelRequired({level: levelName});
+            } else {
+                this[levelName] = noop;
+                this.mainLogger.warn('Child Logger Disabled level',
+                    {level: levelName});
+            }
+        } else {
+            this[levelName] = makeLogMethod(levelName);
         }
-        this[levelName] = makeLogMethod(levelName);
     }, this);
 }
 
@@ -38,3 +46,4 @@ ChildLogger.prototype.createChild = function createChild(subPath, levels) {
     return this.mainLogger.createChild(this.path + '.' + subPath, levels);
 };
 
+function noop() {}

--- a/child-logger.js
+++ b/child-logger.js
@@ -22,15 +22,15 @@ function ChildLogger(config) {
 
     this.fieldObjs.forEach(function validateFields(objConf) {
         if (!objConf || !objConf.object || typeof objConf.object !== 'object') {
-            throw errors.FieldObjectRequired;
+            throw errors.FieldObjectRequired();
         }
         if (!objConf.fields || typeof objConf.fields !== 'object') {
-            throw errors.FieldDefinitionRequired;
+            throw errors.FieldDefinitionRequired();
         }
         Object.keys(objConf.fields).forEach(function validateField(field) {
             var fieldName = objConf.fields[field];
             if (!(typeof fieldName === 'string' || fieldName instanceof String)) {
-                throw errors.FieldBadDef;
+                throw errors.FieldBadDef();
             }
         });
     });
@@ -60,7 +60,6 @@ ChildLogger.prototype.writeEntry = function writeEntry(entry, callback) {
             dotty.put(fieldMeta, fieldName, dotty.get(obj, field));
         });
     }, this);
-    console.log(fieldMeta);
     if (this.extendMeta) {
         // entry meta should always win
         entry.meta = xtend(this.meta, fieldMeta, entry.meta);

--- a/child-logger.js
+++ b/child-logger.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var xtend = require('xtend');
+var dotty = require('dotty');
 
 var defaultLevels = require('./default-levels.js');
 var makeLogMethod = require('./log-method');
@@ -11,12 +12,28 @@ module.exports = ChildLogger;
 function ChildLogger(config) {
     this.mainLogger = config.mainLogger;
     this.path = config.path;
-    if (config.extendMeta && !config.meta) {
+    if (config.extendMeta && !(config.meta || config.fieldObjs)) {
         throw errors.MetaRequired;
     }
     this.extendMeta = config.extendMeta;
-    this.meta = config.meta;
+    this.meta = config.meta || {};
     this.strict = config.strict;
+    this.fieldObjs = config.fieldObjs || [];
+
+    this.fieldObjs.forEach(function validateFields(objConf) {
+        if (!objConf || !objConf.object || typeof objConf.object !== 'object') {
+            throw errors.FieldObjectRequired;
+        }
+        if (!objConf.fields || typeof objConf.fields !== 'object') {
+            throw errors.FieldDefinitionRequired;
+        }
+        Object.keys(objConf.fields).forEach(function validateField(field) {
+            var fieldName = objConf.fields[field];
+            if (!(typeof fieldName === 'string' || fieldName instanceof String)) {
+                throw errors.FieldBadDef;
+            }
+        });
+    });
 
     var levels = config.levels || defaultLevels;
     Object.keys(levels).forEach(function (levelName) {
@@ -35,9 +52,18 @@ function ChildLogger(config) {
 }
 
 ChildLogger.prototype.writeEntry = function writeEntry(entry, callback) {
+    var fieldMeta = {};
+    this.fieldObjs.forEach(function readObjConf(objConf) {
+        var obj = objConf.object;
+        Object.keys(objConf.fields).forEach(function readField(field) {
+            var fieldName = objConf.fields[field];
+            dotty.put(fieldMeta, fieldName, dotty.get(obj, field));
+        });
+    }, this);
+    console.log(fieldMeta);
     if (this.extendMeta) {
         // entry meta should always win
-        entry.meta = xtend(this.meta, entry.meta);
+        entry.meta = xtend(this.meta, fieldMeta, entry.meta);
     }
     this.mainLogger.writeEntry(entry, callback);
 };

--- a/errors.js
+++ b/errors.js
@@ -36,21 +36,22 @@ var LevelDisabled = TypedError({
     message: 'logtron: Child Logger could not enable level' +
         'because backend for {level} does not exist in parent.\n'
 });
-var FieldObjectRequired = TypedError({
-    type: 'logtron.child-logger.field-logger.missing-object',
+var FilterObjectRequired = TypedError({
+    type: 'logtron.child-logger.meta-filter.missing-object',
     message: 'logtron: Child Logger requires an object key' +
-        'containing an object for each object Fields to be logged.\n'
+        'containing an object in each filter.\n'
 });
-var FieldDefinitionRequired = TypedError({
-    type: 'logtron.child-logger.field-logger.missing-definition',
-    message: 'logtron: Child Logger requires at least one field per ' +
-        'each object fields.\n'
+var FilterMappingsRequired = TypedError({
+    type: 'logtron.child-logger.meta-filter.missing-mappings',
+    message: 'logtron: Child Logger requires at least one mapping for' +
+        'each filtered object.\n'
 });
-var FieldBadDef = TypedError({
-    type: 'logtron.child-logger.field-logger.bad-definition',
-    message: 'logtron: Child Logger format for field logging fields is ' +
-        'an object in which the key is the location in the object to fetch the ' +
-        'value from and a string which is the name it will be saved to the meta with.\n'
+var FilterBadDst = TypedError({
+    type: 'logtron.child-logger.meta-filter.bad-definition',
+    message: 'logtron: Format for filters mappings is ' +
+        'an object. Each key is the location in the target object to ' +
+        'fetch the value from; each value is a string which is the ' +
+        'the target destination on the meta object.\n'
 });
 
 module.exports = {
@@ -60,7 +61,7 @@ module.exports = {
     LevelRequired: LevelRequired,
     UniquePathRequired: UniquePathRequired,
     LevelDisabled: LevelDisabled,
-    FieldObjectRequired: FieldObjectRequired,
-    FieldDefinitionRequired: FieldDefinitionRequired,
-    FieldBadDef: FieldBadDef
+    FilterObjectRequired: FilterObjectRequired,
+    FilterMappingsRequired: FilterMappingsRequired,
+    FilterBadDst: FilterBadDst
 };

--- a/errors.js
+++ b/errors.js
@@ -23,7 +23,7 @@ var BackendsRequired = TypedError({
 // The following have been added since the transition to logtron.
 var LevelRequired = TypedError({
     type: 'logtron.child-logger.additional-level.required',
-    message: 'logtron: Logger must configure at least one ' +
+    message: 'logtron: Child Logger in strict mode must configure at least one ' +
         'backend to store log level {level} produced by child logger.\n'
 });
 var UniquePathRequired = TypedError({
@@ -31,11 +31,17 @@ var UniquePathRequired = TypedError({
     message: 'logtron: Child logger must be constructed with ' +
         'a unique path\n. {path} has already been used.\n'
 });
+var LevelDisabled = TypedError({
+    type: 'logtron.child-logger.additional-level.disabled',
+    message: 'logtron: Child Logger could not enable level' +
+        'because backend for {level} does not exist in parent.\n'
+});
 
 module.exports = {
     OptsRequired: OptsRequired,
     MetaRequired: MetaRequired,
     BackendsRequired: BackendsRequired,
     LevelRequired: LevelRequired,
-    UniquePathRequired: UniquePathRequired
+    UniquePathRequired: UniquePathRequired,
+    LevelDisabled: LevelDisabled
 };

--- a/errors.js
+++ b/errors.js
@@ -36,6 +36,22 @@ var LevelDisabled = TypedError({
     message: 'logtron: Child Logger could not enable level' +
         'because backend for {level} does not exist in parent.\n'
 });
+var FieldObjectRequired = TypedError({
+    type: 'logtron.child-logger.field-logger.missing-object',
+    message: 'logtron: Child Logger requires an object key' +
+        'containing an object for each object Fields to be logged.\n'
+});
+var FieldDefinitionRequired = TypedError({
+    type: 'logtron.child-logger.field-logger.missing-definition',
+    message: 'logtron: Child Logger requires at least one field per ' +
+        'each object fields.\n'
+});
+var FieldBadDef = TypedError({
+    type: 'logtron.child-logger.field-logger.bad-definition',
+    message: 'logtron: Child Logger format for field logging fields is ' +
+        'an object in which the key is the location in the object to fetch the ' +
+        'value from and a string which is the name it will be saved to the meta with.\n'
+});
 
 module.exports = {
     OptsRequired: OptsRequired,
@@ -43,5 +59,8 @@ module.exports = {
     BackendsRequired: BackendsRequired,
     LevelRequired: LevelRequired,
     UniquePathRequired: UniquePathRequired,
-    LevelDisabled: LevelDisabled
+    LevelDisabled: LevelDisabled,
+    FieldObjectRequired: FieldObjectRequired,
+    FieldDefinitionRequired: FieldDefinitionRequired,
+    FieldBadDef: FieldBadDef
 };

--- a/logger.js
+++ b/logger.js
@@ -182,7 +182,8 @@ Logger.prototype.createChild = function createChild(path, levels, opts) {
         path: path,
         levels: levels,
         extendMeta: opts.extendMeta,
-        meta: opts.meta
+        meta: opts.meta,
+        strict: opts.strict
     });
 };
 

--- a/logger.js
+++ b/logger.js
@@ -183,7 +183,8 @@ Logger.prototype.createChild = function createChild(path, levels, opts) {
         levels: levels,
         extendMeta: opts.extendMeta,
         meta: opts.meta,
-        strict: opts.strict
+        strict: opts.strict,
+        fieldObjs: opts.fieldObjs
     });
 };
 

--- a/logger.js
+++ b/logger.js
@@ -184,7 +184,7 @@ Logger.prototype.createChild = function createChild(path, levels, opts) {
         extendMeta: opts.extendMeta,
         meta: opts.meta,
         strict: opts.strict,
-        fieldObjs: opts.fieldObjs
+        metaFilter: opts.metaFilter
     });
 };
 

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "airlock": "^2.1.1",
     "core-util-is": "^1.0.1",
     "deep-extend": "0.4.0",
+    "dotty": "0.0.2",
     "error": "^7.0.1",
     "inherits": "^2.0.1",
     "kafka-logger": "^5.0.1",

--- a/test/child-logger.js
+++ b/test/child-logger.js
@@ -103,3 +103,31 @@ test('child logger can not be constructed ' +
     });
     assert.end();
 });
+
+test('child logger can be constructed ' +
+    'with extra levels without strict', function t(assert) {
+
+    var logger = createLogger();
+    var childLogger;
+    assert.ok(captureStdio('warn: Child Logger Disabled level level=floop', function t() {
+        childLogger = logger.createChild('child', {info: true, floop: true}, 'Got warning for disabled level');
+    }));
+    assert.ok(captureStdio('info: child: hello who=world', function t() {
+        childLogger.info('hello', { who: 'world' });
+    }), 'Enabled levels can log');
+    assert.notok(captureStdio('floop: child: hello who=world', function t() {
+        childLogger.floop('hello', { who: 'world' });
+    }), 'Disabled levels do not log');
+
+    assert.end();
+});
+
+test('child logger can not be constructed ' +
+    'with extra levels with strict', function t(assert) {
+
+    var logger = createLogger();
+    assert.throws(function () {
+        logger.createChild('child', {info: true, floop:true}, {strict: true});
+    });
+    assert.end();
+});

--- a/test/child-logger.js
+++ b/test/child-logger.js
@@ -82,6 +82,23 @@ test('child logger can extend meta', function t(assert) {
     assert.end();
 });
 
+test('child logger can log fields meta', function t(assert) {
+    var foo = {bar: 'baz'};
+    var logger = createLogger();
+    var childLogger = logger.createChild('child', {info: true},
+        {extendMeta: true, fieldObjs: [{object: foo, fields:{bar:'fooBar'}}]});
+
+    assert.ok(captureStdio('info: child: hello fooBar=baz, who=world', function t() {
+        childLogger.info('hello', { who: 'world' });
+    }));
+    foo.bar = 'qux';
+    assert.ok(captureStdio('info: child: hello fooBar=qux, who=world', function t() {
+        childLogger.info('hello', { who: 'world' });
+    }));
+
+    assert.end();
+});
+
 test('child logger can not be constructed ' +
     'with duplicate path indirectly', function t(assert) {
 
@@ -95,11 +112,31 @@ test('child logger can not be constructed ' +
 });
 
 test('child logger can not be constructed ' +
-    'without meta when asked to extend meta', function t(assert) {
+    'without meta or fields when asked to extend meta', function t(assert) {
 
     var logger = createLogger();
     assert.throws(function () {
         logger.createChild('child', {info: true}, {extendMeta: true});
+    });
+    assert.end();
+});
+
+test('child logger can not be constructed ' +
+    'with bad field config', function t(assert) {
+    var foo = {bar: 'baz'};
+
+    var logger = createLogger();
+    assert.throws(function () {
+        logger.createChild('child', {info: true}, 
+            {extendMeta: true, fieldObjs: [{fields:{bar:'fooBar'}}]});
+    });
+    assert.throws(function () {
+        logger.createChild('child1', {info: true}, 
+            {extendMeta: true, fieldObjs: [{object: foo}]});
+    });
+    assert.throws(function () {
+        logger.createChild('child2', {info: true}, 
+            {extendMeta: true, fieldObjs: [{object: foo, fields:{bar:{}}}]});
     });
     assert.end();
 });

--- a/test/child-logger.js
+++ b/test/child-logger.js
@@ -82,11 +82,11 @@ test('child logger can extend meta', function t(assert) {
     assert.end();
 });
 
-test('child logger can log fields meta', function t(assert) {
+test('child logger can log filtered meta', function t(assert) {
     var foo = {bar: 'baz'};
     var logger = createLogger();
     var childLogger = logger.createChild('child', {info: true},
-        {extendMeta: true, fieldObjs: [{object: foo, fields:{bar:'fooBar'}}]});
+        {extendMeta: true, metaFilter: [{object: foo, mappings:{bar:'fooBar'}}]});
 
     assert.ok(captureStdio('info: child: hello fooBar=baz, who=world', function t() {
         childLogger.info('hello', { who: 'world' });
@@ -128,15 +128,15 @@ test('child logger can not be constructed ' +
     var logger = createLogger();
     assert.throws(function () {
         logger.createChild('child', {info: true}, 
-            {extendMeta: true, fieldObjs: [{fields:{bar:'fooBar'}}]});
+            {extendMeta: true, metaFilter: [{mappings:{bar:'fooBar'}}]});
     });
     assert.throws(function () {
         logger.createChild('child1', {info: true}, 
-            {extendMeta: true, fieldObjs: [{object: foo}]});
+            {extendMeta: true, metaFilter: [{object: foo}]});
     });
     assert.throws(function () {
         logger.createChild('child2', {info: true}, 
-            {extendMeta: true, fieldObjs: [{object: foo, fields:{bar:{}}}]});
+            {extendMeta: true, metaFilter: [{object: foo, mappings:{bar:{}}}]});
     });
     assert.end();
 });


### PR DESCRIPTION
This makes it possible to pass the child logger a set of fields you want it to watch. By doing it this way even if the value on an object changes whenever you log the fieldsMeta will be up to date.

cc @Raynos @Matt-Esch @jcorbin @jskelcy 