### PR TITLE
Adding support for kafka rest client

### DIFF
--- a/backends/kafka.js
+++ b/backends/kafka.js
@@ -23,6 +23,8 @@ function KafkaBackend(opts) {
     this.properties = opts.properties || {};
     this.leafHost = opts.leafHost || 'localhost';
     this.leafPort = opts.leafPort || 9093;
+    this.proxyHost = opts.proxyHost || 'localhost';
+    this.proxyPort = opts.proxyPort;
     this.statsd = opts.statsd || null;
     this.kafkaClient = opts.kafkaClient || null;
     this.isDisabled = opts.isDisabled || null;
@@ -43,6 +45,8 @@ KafkaBackend.prototype.createStream =
             },
             leafHost: this.leafHost,
             leafPort: this.leafPort,
+            proxyHost: this.proxyHost,
+            proxyPort: this.proxyPort,
             kafkaClient: this.kafkaClient,
             isDisabled: this.isDisabled,
             kafkaProber: new Prober({

--- a/backends/kafka.js
+++ b/backends/kafka.js
@@ -71,6 +71,9 @@ KafkaBackend.prototype.createStream =
             if (logger.kafkaClient.zk) {
                 logger.kafkaClient.zk.close();
             }
+            if (logger.kafkaRestClient) {
+                logger.kafkaRestClient.close();
+            }
         });
     };
 

--- a/index.js
+++ b/index.js
@@ -62,6 +62,8 @@ function defaultBackends(config, clients) {
         kafka: config.kafka ? Kafka({
             leafHost: config.kafka.leafHost,
             leafPort: config.kafka.leafPort,
+            proxyHost: config.kafka.proxyHost,
+            proxyPort: config.kafka.proxyPort,
             isDisabled: clients.isKafkaDisabled,
             statsd: clients.statsd,
             kafkaClient: clients.kafkaClient

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "dotty": "0.0.2",
     "error": "^7.0.1",
     "inherits": "^2.0.1",
-    "kafka-logger": "^5.0.1",
+    "kafka-logger": "^6.0.1",
     "lodash.isfinite": "~2.4.1",
     "mkdirp": "~0.3.5",
     "nodemailer": "~0.5.14",

--- a/test/kafka.js
+++ b/test/kafka.js
@@ -1,5 +1,7 @@
 var test = require('tape');
 var test = require('tape');
+
+var http = require('http');
 var KafkaServer = require(
     'kafka-logger/test/lib/kafka-server.js');
 
@@ -34,4 +36,63 @@ test('kafka logging', function (assert) {
     });
 
     logger.info('writing to kafka');
+});
+
+
+test('kafka logging with rest client', function(assert) {
+    var server = KafkaServer(function onMessage(msg) {
+        assert.equal(msg.topic, 'rt-foobarx');
+        var obj = msg.messages[0].payload;
+        assert.equal(obj.level, 'info');
+        assert.ok(obj.msg.indexOf('writing to kafka') !== -1);
+        server.close();
+    });
+
+    var restProxyPort = 10000 + Math.floor(Math.random() * 20000);
+    var restProxyServer = http.createServer(function(req, res) {
+        var url = 'localhost:' + restProxyPort;
+        var messages = {};
+        messages[url] = ['rt-foobarx'];
+        if (req.method === 'GET') {
+            res.end(JSON.stringify(messages));
+        } else if (req.method === 'POST') {
+            assert.ok(req.headers.timestamp);
+            assert.equal(req.url, '/topics/rt-foobarx');
+            var body = '';
+            req.on('data', function (data) {
+                body += data;
+            });
+            req.on('end', function () {
+                assert.ok(body.indexOf('info') !== -1);
+                assert.ok(body.indexOf('writing to kafka') !== -1);
+            });
+        }
+    }).listen(restProxyPort);
+    restProxyServer.addListener( "connection", function( socket ) {
+        setTimeout(function() {
+          socket.destroy();
+        },1000);
+    } );
+
+    var logger = Logger({
+        meta: {
+            team: 'rt',
+            project: 'foobarx'
+        },
+        backends: {
+            kafka: KafkaBackend({
+                leafHost: 'localhost',
+                leafPort: server.port,
+                proxyHost: 'localhost',
+                proxyPort: restProxyPort
+            })
+        }
+    });
+
+    logger.info('writing to kafka');
+    setTimeout(function() {
+        logger.destroy();
+        restProxyServer.close();
+        assert.end();
+    },100);
 });

--- a/test/kafka.js
+++ b/test/kafka.js
@@ -47,7 +47,7 @@ test('kafka logging with rest client', function(assert) {
         assert.ok(obj.msg.indexOf('writing to kafka') !== -1);
         server.close();
     });
-
+    var count = 0;
     var restProxyPort = 10000 + Math.floor(Math.random() * 20000);
     var restProxyServer = http.createServer(function(req, res) {
         var url = 'localhost:' + restProxyPort;
@@ -66,13 +66,10 @@ test('kafka logging with rest client', function(assert) {
                 assert.ok(body.indexOf('info') !== -1);
                 assert.ok(body.indexOf('writing to kafka') !== -1);
             });
+            count++;
+            res.end();
         }
     }).listen(restProxyPort);
-    restProxyServer.addListener( "connection", function( socket ) {
-        setTimeout(function() {
-          socket.destroy();
-        },1000);
-    } );
 
     var logger = Logger({
         meta: {
@@ -91,6 +88,7 @@ test('kafka logging with rest client', function(assert) {
 
     logger.info('writing to kafka');
     setTimeout(function() {
+        assert.equal(count, 1);
         logger.destroy();
         restProxyServer.close();
         assert.end();


### PR DESCRIPTION
If no proxyPort been set, kafka rest client won't be initialized.