### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,7 +364,7 @@ Opts specifies options for the child logger. The available
   options are to enable strict mode, and to add metadata to
   each entry. To enable strict mode pass the `strict` key in
   the options with a true value. In strict mode the child
-  logger will ensure that each log level has a corrisponding
+  logger will ensure that each log level has a corresponding
   backend in the parent logger. Otherwise the logger will
   replace any missing parent methods with a no-op function.
   If you wish to add meta data to each log entry the child


### PR DESCRIPTION
@uber, I've corrected a typographical error in the documentation of the [logtron](https://github.com/uber/logtron) project. Specifically, I've changed corrisponding to corresponding. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.