### PR TITLE
do not log 'nonObjectMeta' when it's undefined

### DIFF
--- a/log-method.js
+++ b/log-method.js
@@ -30,7 +30,7 @@ function makeLogMethod(levelName) {
     function log(message, meta, callback) {
         /*jshint validthis:true*/
 
-        if (typeof meta !== 'object' || meta === null) {
+        if (meta !== undefined && (typeof meta !== 'object' || meta === null)) {
             meta = {
                 nonObjectMeta: meta
             };


### PR DESCRIPTION
logging undefineds really pollutes the log stream.

instead of

```
2016-04-28T22:45:47.635Z - info: did a thing nonObjectMeta=undefined
```

we now have

```
2016-04-28T22:45:47.635Z - info: did a thing
```