### PR TITLE
expand less levels when dump circular objects

### DIFF
--- a/transforms/safe-serialize-meta.js
+++ b/transforms/safe-serialize-meta.js
@@ -31,7 +31,7 @@ function safeSerializeMeta(entry) {
     var serializedFailed = trySerialize(meta);
 
     if (serializedFailed !== null) {
-        var entryString = util.inspect(entry, { depth: null });
+        var entryString = util.inspect(entry, { depth: 4 });
         meta = {
             error: 'logtron failed to serialize meta',
             reason: serializedFailed.message,


### PR DESCRIPTION
Since the changes made in 5c521f01, I've seen in production that someone tried to log some huge circular objects and expanding indefinitely will generate result string in hundreds of MBs. Picked a reasonable level of 4 should give us a good understanding of what the object looks like, while not run into danger of aborting the process. 