### PR TITLE
avoid pathelogical util.inspect

### DIFF
--- a/transforms/safe-serialize-meta.js
+++ b/transforms/safe-serialize-meta.js
@@ -21,7 +21,6 @@
 'use strict';
 
 var Entry = require('../entry.js');
-var util = require('util');
 
 module.exports = safeSerializeMeta;
 
@@ -31,12 +30,13 @@ function safeSerializeMeta(entry) {
     var serializedFailed = trySerialize(meta);
 
     if (serializedFailed !== null) {
-        var entryString = util.inspect(entry, { depth: 4 });
         meta = {
             error: 'logtron failed to serialize meta',
             reason: serializedFailed.message,
             stack: serializedFailed.stack,
-            entry: entryString
+            entryKeys: Object.keys(meta),
+            entryLevel: entry.level,
+            entryMessage: entry.message
         };
     }
 


### PR DESCRIPTION
This util.inspect() can dominate the CPU.

When a logsite fails with a non-serializable meta we should instead just
print the top level keys and move on.

r: @Matt-Esch