### PR TITLE
Provide prober settings to sentry-logger

### DIFF
--- a/backends/sentry.js
+++ b/backends/sentry.js
@@ -62,12 +62,15 @@ SentryBackend.prototype.createStream =
             sentryProber: new Prober({
                 title: 'sentry',
                 enabled: true,
-                detectFailuresBy: 'event',
                 statsd: backend.statsd,
                 backend: ravenClient,
+                detectFailuresBy: Prober.detectBy.EVENT,
                 failureEvent: 'error',
                 successEvent: 'logged'
-            })
+            }),
+            sentryProberDetectFailuresBy: SentryLogger.detectBy.EVENT,
+            sentryProberDetectFailuresByEventFailureEvent: 'error',
+            sentryProberDetectFailuresByEventSuccessEvent: 'logged'
         });
 
         return LoggerStream(logger, {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "lodash.isfinite": "~2.4.1",
     "mkdirp": "~0.3.5",
     "readable-stream": "^1.0.27-1",
-    "sentry-logger": "^3.0.4",
+    "sentry-logger": "^3.0.7",
     "uber-raven": "^0.6.3-project-name",
     "winston-uber": "^1.0.0",
     "xtend": "^4.0.0"


### PR DESCRIPTION
Provide prober settings to sentry-logger so that log callbacks are oly called after completion