### PR TITLE
Fix meta propagation for grand-child loggers.

### DIFF
--- a/child-logger.js
+++ b/child-logger.js
@@ -97,8 +97,8 @@ ChildLogger.prototype.writeEntry = function writeEntry(entry, callback) {
     this.mainLogger.writeEntry(entry, callback);
 };
 
-ChildLogger.prototype.createChild = function createChild(subPath, levels, options) {
-    return this.mainLogger.createChild(this.path + '.' + subPath, levels, options, this);
+ChildLogger.prototype.createChild = function createChild(subPath, levels, options, mainLogger) {
+    return this.mainLogger.createChild(this.path + '.' + subPath, levels, options, mainLogger || this);
 };
 
 function noop() {}

--- a/test/child-logger.js
+++ b/test/child-logger.js
@@ -106,6 +106,26 @@ test('child logger can merge parent meta', function t(assert) {
     assert.end();
 });
 
+test('child logger can merge grandparent meta', function t(assert) {
+    var logger = createLogger({bar: 'baz'});
+    var childLogger = logger.createChild(
+        'child',
+        {info: true},
+        {extendMeta: true, meta: {foo: 'bar'}, mergeParentMeta: true}
+    );
+    var grandChildLogger = childLogger.createChild(
+        'grandchild',
+        {info: true},
+        {extendMeta: true, meta: {baz: 'biz'}, mergeParentMeta: true}
+    );
+
+    assert.ok(captureStdio('info: child.grandchild: hello bar=baz, foo=bar, baz=biz, who=world', function t() {
+        grandChildLogger.info('hello', { who: 'world' });
+    }));
+
+    assert.end();
+});
+
 test('child logger can log filtered meta', function t(assert) {
     var foo = {bar: 'baz'};
     var logger = createLogger();


### PR DESCRIPTION
Meta propagation currently only works one level deep because we pass
the wrong logger to ChildLogger.createChild when the call is nested.